### PR TITLE
fixed `NestedStackRouter` used after being disposed issue

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1173,6 +1173,7 @@ class NestedStackRouter extends StackRouter {
   final RouteCollection routeCollection;
   final PageBuilder pageBuilder;
   final bool managedByWidget;
+  bool _disposed = false;
 
   RouteData _routeData;
 
@@ -1221,6 +1222,19 @@ class NestedStackRouter extends StackRouter {
 
   @override
   NavigationHistory get navigationHistory => root.navigationHistory;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    if (!_disposed) {
+      super.removeListener(listener);
+    }
+  }
 }
 
 class _RouterScopeResult<T extends RoutingController> {


### PR DESCRIPTION
`StackRouter` fix we applied in `dispose` method doesn't affect the 'used after being disposed' issue. The reason is that completely independent sequence of `dispose` events is executed after the `dispose` was called on the `StackRouter`. 

The proposed solution definitely works, but I'm not sure it's optimal one, because it doesn't handle `removeListener` call.